### PR TITLE
discrete memory mapping

### DIFF
--- a/playbooks/group_vars/containerhost.yml
+++ b/playbooks/group_vars/containerhost.yml
@@ -4,6 +4,11 @@
 nexcess_repo_enabled: false
 server_selinux_enforcing: false
 
+## Allow docker to discretely map more memory; incidentally this also is needed later for ES
+server_extra_sysctl:
+  - key: "vm.max_map_count"
+    value: 393216
+
 ## Firewall - Ultimately handled by APF but set this to start
 firewall_v4_group_rules:
   401 allow iworx to the world:


### PR DESCRIPTION
Allow docker to discretely map more memory; incidentally, this also is needed later for ES at scale