### PR TITLE
Docker 'fix':

### DIFF
--- a/playbooks/tasks/containerhost.yml
+++ b/playbooks/tasks/containerhost.yml
@@ -1,5 +1,23 @@
 ---
-- name: Template daemon.json File
+
+- name: "Create Override Dir For 'fix'"
+  file:
+    path: "/etc/systemd/system/docker.service.d/"
+    owner: "root"
+    group: "root"
+    mode: 0755
+  when: mode == 'post'
+
+- name: "Fix Docker docker-ce-18.09.0-3.el7 Issues"
+  template:
+    src: "daemon-override.conf.j2"
+    dest: "/etc/systemd/system/docker.service.d/override.conf"
+    owner: "root"
+    group: "root"
+    mode: 0644
+  when: mode == 'post'
+
+- name: "Template daemon.json File"
   template:
     src: "daemon.json.j2"
     dest: "/etc/docker/daemon.json"
@@ -8,8 +26,9 @@
     mode: 0644
   when: mode == 'post'
 
-- name: Restart Docker
+- name: "Restart Docker"
   service:
     name: "docker"
     state: "restarted"
+    daemon_reload: true
   when: mode == 'post'


### PR DESCRIPTION
[11:49 PM] Stephen Dunne: so, 4 step process for fix
[11:50 PM] Stephen Dunne:
    1) mkdir /etc/systemd/system/docker.service.d/
    2) create /etc/systemd/system/docker.service.d/override.conf
    3) systemctl daemon-reload
    4) start/restart docker
[11:50 PM] Stephen Dunne: content of file needs to be
[11:50 PM] Stephen Dunne:
    $ cat override.conf
    [Service]
    # This line resets / "removes" the original ExecStart as was defined in the main systemd unit file
    ExecStart=
    # This line defines the new ExecStart to use _instead_
    ExecStart=/usr/bin/dockerd