### PR TITLE
update daemon.json template

### DIFF
--- a/playbooks/templates/daemon.json.j2
+++ b/playbooks/templates/daemon.json.j2
@@ -2,5 +2,7 @@
   "tls": true,
   "tlscert": "/etc/puppetlabs/puppet/ssl/certs/{{ puppet_uuid }}.pem",
   "tlskey": "/etc/puppetlabs/puppet/ssl/private_keys/{{ puppet_uuid }}.pem",
+  "tlscacert": "/etc/puppetlabs/puppet/ssl/ca.pem",
+  "tlsverify": false,
   "hosts": ["tcp://{{ backnet_addr }}:2376", "unix:///var/run/docker.sock"]
 }


### PR DESCRIPTION
The default behavior changed sometime between the Docker 19.03 and 20.10 releases, and this preserves the old behavior of the systems (for now) to allow deploying with current Docker versions.