### PR TITLE
pin to docker 4.4.4 python module

### DIFF
--- a/playbooks/tasks/containerhost.yml
+++ b/playbooks/tasks/containerhost.yml
@@ -36,7 +36,7 @@
 
 - name: "Install docker-py Module"
   pip:
-    name: "docker"
+    name: "docker==4.4.4"
   when:
     - mode == 'post'
     - nex_docker_login_enabled


### PR DESCRIPTION
pin to docker 4.4.4 python module. The next release of docker python module (5.0.0) drops support for python2 which causes the playbook to fail.