### PR TITLE
Use python3 for containerhost specific steps instead of python 2

### DIFF
--- a/playbooks/tasks/containerhost.yml
+++ b/playbooks/tasks/containerhost.yml
@@ -1,5 +1,15 @@
 ---
 
+- name: "Install python 3"
+  package:
+    name: python3
+    state: present
+  when: mode == 'post'
+
+- set_fact:
+    ansible_python_interpreter: "/bin/python3"
+  when: mode == 'post'
+
 - name: "Create Override Dir For 'fix'"
   file:
     path: "/etc/systemd/system/docker.service.d/"
@@ -34,9 +44,16 @@
     daemon_reload: true
   when: mode == 'post'
 
+- name: "Install six module"
+  pip:
+    name: "six"
+  when:
+    - mode == 'post'
+    - nex_docker_login_enabled
+
 - name: "Install docker-py Module"
   pip:
-    name: "docker==4.4.4"
+    name: "docker"
   when:
     - mode == 'post'
     - nex_docker_login_enabled


### PR DESCRIPTION
Python packages for python2 are slowly being deprecated and removed leaving us having to pin more and more packages to old versions. This fix installs and switches Ansible to using python3 for all containerhost tasks. This should put us in a place where we do not have to worry about python2 package deprecation anymore.