### PR TITLE
pin to certifi 2021.10.8

### DIFF
--- a/playbooks/tasks/containerhost.yml
+++ b/playbooks/tasks/containerhost.yml
@@ -41,6 +41,13 @@
     - mode == 'post'
     - nex_docker_login_enabled
 
+- name: "Install certifi Module"
+  pip:
+    name: "certifi==2021.10.8"
+  when:
+    - mode == 'post'
+    - nex_docker_login_enabled
+
 - name: "Install docker-py Module"
   pip:
     name: "docker==4.4.4"


### PR DESCRIPTION
We have to pin certifi to version 2021.10.8 and install it before we install the docker module, otherwise pip will pull in a newer version of certifi that is only compatible with Python3 which completely breaks python/pip.