### PR TITLE
Pin requests version to 2.28 now as well

### DIFF
--- a/playbooks/tasks/containerhost.yml
+++ b/playbooks/tasks/containerhost.yml
@@ -41,6 +41,13 @@
     - mode == 'post'
     - nex_docker_login_enabled
 
+- name: "Install requests Module"
+  pip:
+    name: "requests==2.28"
+  when:
+    - mode == 'post'
+    - nex_docker_login_enabled
+
 - name: "Install certifi Module"
   pip:
     name: "certifi==2021.10.8"

--- a/playbooks/tasks/containerhost.yml
+++ b/playbooks/tasks/containerhost.yml
@@ -43,7 +43,7 @@
 
 - name: "Install requests Module"
   pip:
-    name: "requests==2.28"
+    name: "requests==2.27.1"
   when:
     - mode == 'post'
     - nex_docker_login_enabled


### PR DESCRIPTION
~~~
[root@containerhost-5368884 stark]# pip install docker==4.4.4
Collecting docker==4.4.4
  Using cached https://files.pythonhosted.org/packages/c4/22/410313ad554477e87ec406d38d85f810e61ddb0d2fc44e64994857476de9/docker-4.4.4-py2.py3-none-any.whl
Requirement already satisfied (use --upgrade to upgrade): six>=1.4.0 in /usr/lib/python2.7/site-packages (from docker==4.4.4)
Requirement already satisfied (use --upgrade to upgrade): ipaddress>=1.0.16; python_version < "3.3" in /usr/lib/python2.7/site-packages (from docker==4.4.4)
Requirement already satisfied (use --upgrade to upgrade): backports.ssl-match-hostname>=3.5; python_version < "3.5" in /usr/lib/python2.7/site-packages (from docker==4.4.4)
Collecting requests!=2.18.0,>=2.14.2 (from docker==4.4.4)
  Using cached https://files.pythonhosted.org/packages/e9/23/384d9953bb968731212dc37af87cb75a885dc48e0615bd6a303577c4dc4b/requests-2.28.0.tar.gz
    Complete output from command python setup.py egg_info:

    ==========================
    Unsupported Python version
    ==========================
    This version of Requests requires at least Python 3.7, but
    you're trying to install it on Python 2.7. To resolve this,
    consider upgrading to a supported Python version.

    If you can't upgrade your Python version, you'll need to
    pin to an older version of Requests (<2.28).

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-eDsCxf/requests/
You are using pip version 8.1.2, however version 22.1.2 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
~~~